### PR TITLE
[Proposal] Compact array after readdirsync

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -117,7 +117,8 @@ function update({ config, stdout }) {
           definition: functionDef,
         };
       } catch(e) { return; }
-    });
+    })
+    .filter((i) => i);
 
   const swagger = {
     "swagger": "2.0",


### PR DESCRIPTION
Related to #5 

When trying to invoke `update` function the error below was showed to me:
```javascript
Cannot match against 'undefined' or 'null'.
```
The problem was happening on `destructuring` present in line `87`, after debugging I found out that the array of functions had an `undefined` item because inside the `function's` I had a `.DS_Store` file.

```javascript
[undefined, { ... }, { ... }]
```

My proposal is to filter results right away after readdsync map instruction.